### PR TITLE
use evalpoly instead of manual loops for series approximations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.3
+  - 1.4
   - nightly
 branches:
   only:
@@ -15,7 +15,7 @@ jobs:
     - julia: nightly
   include:
     - stage: "Documentation"
-      julia: 1.3
+      julia: 1.4
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg;

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ BetterExp = "0.1"
 Documenter = "0.24, 0.25"
 SpecialFunctions = "0.10, 1"
 StaticArrays = "0.12, 1"
-julia = "1.3"
+julia = "1.4"
 
 [extras]
 BetterExp = "7cffe744-45fd-4178-b173-cf893948b8b7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 1.3
+  - julia_version: 1.4
   - julia_version: nightly
 
 platform:

--- a/src/ModifiedHankelFunctionsOfOrderOneThird.jl
+++ b/src/ModifiedHankelFunctionsOfOrderOneThird.jl
@@ -13,7 +13,7 @@ export modifiedhankel
 # Number of terms to sum in both `powerseries` and `asymptotic` solutions
 # Larger `NUMTERMS` generate successively smaller values, but can lead to floating point
 # errors when multiplied against successively larger powers of `z`.
-const NUMTERMS = 30
+const NUMTERMS = 20
 
 # Series for auxiliary functions `f`, `f′`, `g`, and `g′` in `powerseries`.
 const a₀ = cbrt(2)/gamma(2/3)

--- a/test/ModifiedHankelFunctionTests.jl
+++ b/test/ModifiedHankelFunctionTests.jl
@@ -3,7 +3,7 @@ using ModifiedHankelFunctionsOfOrderOneThird
 using SpecialFunctions
 using BetterExp
 
-@testset "Zeros of h₂" begin
+@testset "Power series: zeros of h₂" begin
     h1, h2, h1p, h2p = modifiedhankel(complex(-1.16905371, 2.02486041))
     @test h1 ≈ complex(-0.34342750, 0.59483387)
     @test h1p ≈ complex(-0.06957489, -1.06099210)
@@ -20,7 +20,7 @@ using BetterExp
     @test h2p ≈ complex(-2.26747600, 1.30912788)
 end
 
-@testset "Zeros of h₂′" begin
+@testset "Power series: zeros of h₂′" begin
     h1, h2, h1p, h2p = modifiedhankel(complex(-0.50939649, 0.88230059))
     @test h1 ≈ complex(-0.63166599, -0.52691131)
     @test h2 ≈ complex(0, 1.62098891)
@@ -37,7 +37,7 @@ end
     @test h1p ≈ complex(1.26609349, 0)
 end
 
-@testset "Spot checks" begin
+@testset "Power series: spot checks" begin
     h1, h2, h1p, h2p = modifiedhankel(complex(2., 0.))
     @test h1 ≈ complex(0.60991262, 0.36822576)
     @test h1p ≈ complex(-0.59922801, 0.83306447)


### PR DESCRIPTION
This addresses issue #18 and provides a ~19% speedup for asymptotic expansion solution and a ~25% speedup for the power series solution.

This pull request additionally reduces the number of terms used in the series from 30 to 20. This leads to a further speedup and doesn't appear to reduce accuracy at least for Float64 inputs.